### PR TITLE
feat(backend): implementar APIs de turnos médicos y reservas

### DIFF
--- a/backend/BACKEND_GUIDE.md
+++ b/backend/BACKEND_GUIDE.md
@@ -1,0 +1,70 @@
+# Guia Del Backend SkipLine
+
+Este archivo explica el proposito de cada zona del backend para facilitar onboarding a personas sin contexto del proyecto.
+
+## Flujo principal
+
+1. AuthController recibe registro/login.
+2. AuthService valida reglas de rol y emite JWT.
+3. JwtAuthenticationFilter valida token en cada request protegido.
+4. Controladores de dominio delegan en servicios transaccionales.
+5. Repositorios encapsulan consultas de JPA.
+6. GlobalExceptionHandler estandariza errores HTTP.
+
+## Mapa por paquete
+
+### controller
+- AuthController: alta e inicio de sesion.
+- UserController: administracion de usuarios y perfil propio.
+- DoctorController: catalogo de doctores y agenda diaria.
+- HorarioController: alta de horarios base semanales.
+- SlotController: generacion masiva de slots de 30 minutos.
+- CitaController: reserva transaccional de turnos.
+
+### service
+- AuthService: registro/login y politicas de rol.
+- UserService: altas administrativas y proyecciones de usuario.
+- DoctorService: filtros de busqueda y disponibilidad proxima.
+- HorarioService: validacion de superposicion de bloques.
+- SlotService: expansion de horarios base a slots concretos.
+- CitaService: bloqueo de slot y creacion de cita sin doble reserva.
+
+### Security
+- SecurityConfig: rutas publicas/protegidas y configuracion stateless.
+- JwtService: firma, claims y validacion de tokens.
+- JwtAuthenticationFilter: integra JWT al SecurityContext.
+- CustomUserDetailsService: carga usuarios para autenticacion.
+- UserPrincipal: adapta Usuario a UserDetails.
+
+### entity
+- Usuario y Role: identidad y autorizacion.
+- Doctor y Especialidad: catalogo medico.
+- HorarioBase: disponibilidad semanal.
+- Slot y SlotEstado: franjas agendables.
+- Cita y CitaEstado: reserva confirmada y ciclo de vida.
+
+### repository
+- UsuarioRepository: consultas por email.
+- DoctorRepository: listado con filtros y join de especialidades.
+- HorarioBaseRepository: busqueda de superposicion.
+- SlotRepository: agenda por fecha y bloqueo pesimista.
+- CitaRepository: control de unicidad por slot.
+
+### dto
+- auth: entrada/salida de autenticacion.
+- user: contratos de alta admin y perfil.
+- doctor: respuesta de listado de catalogo.
+- horario: alta y salida de horario base.
+- slot: consulta y generacion de disponibilidad.
+- cita: reserva de turnos y confirmacion.
+- common: error unificado para respuestas de fallo.
+
+### exception
+- Excepciones de negocio especificas (email duplicado, superposicion, slot ocupado, etc.).
+- GlobalExceptionHandler traduce excepciones a codigos HTTP estables.
+
+## Archivos de infraestructura
+
+- src/main/resources/application.properties: datasource, JPA validate, JWT y swagger path.
+- sql/01_align_skipline_schema.sql: alineacion de esquema MySQL con el modelo JPA.
+- pom.xml: dependencias y build Maven.

--- a/backend/sql/01_align_skipline_schema.sql
+++ b/backend/sql/01_align_skipline_schema.sql
@@ -60,32 +60,123 @@ ALTER TABLE Cita
     MODIFY estado VARCHAR(20) NOT NULL DEFAULT 'RESERVADA';
 
 -- 4) Checks de valores válidos (MySQL 8+)
-ALTER TABLE Usuario
-    ADD CONSTRAINT chk_usuario_rol
-    CHECK (rol IN ('ADMIN', 'MEDICO', 'PACIENTE'));
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE constraint_schema = DATABASE()
+      AND constraint_name = 'chk_usuario_rol'
+      AND table_name = 'Usuario'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE Usuario ADD CONSTRAINT chk_usuario_rol CHECK (rol IN (''ADMIN'', ''MEDICO'', ''PACIENTE''))',
+    'SELECT ''chk_usuario_rol ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-ALTER TABLE Slot
-    ADD CONSTRAINT chk_slot_estado
-    CHECK (estado IN ('DISPONIBLE', 'RESERVADO', 'CANCELADO'));
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE constraint_schema = DATABASE()
+      AND constraint_name = 'chk_slot_estado'
+      AND table_name = 'Slot'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE Slot ADD CONSTRAINT chk_slot_estado CHECK (estado IN (''DISPONIBLE'', ''OCUPADO'', ''RESERVADO'', ''CANCELADO''))',
+    'SELECT ''chk_slot_estado ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-ALTER TABLE Cita
-    ADD CONSTRAINT chk_cita_estado
-    CHECK (estado IN ('RESERVADA', 'CONFIRMADA', 'ATENDIDA', 'CANCELADA'));
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE constraint_schema = DATABASE()
+      AND constraint_name = 'chk_cita_estado'
+      AND table_name = 'Cita'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE Cita ADD CONSTRAINT chk_cita_estado CHECK (estado IN (''RESERVADA'', ''CONFIRMADA'', ''ATENDIDA'', ''CANCELADA''))',
+    'SELECT ''chk_cita_estado ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-ALTER TABLE HorarioBase
-    ADD CONSTRAINT chk_horario_dia_semana
-    CHECK (dia_semana BETWEEN 1 AND 7);
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE constraint_schema = DATABASE()
+      AND constraint_name = 'chk_horario_dia_semana'
+      AND table_name = 'HorarioBase'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE HorarioBase ADD CONSTRAINT chk_horario_dia_semana CHECK (dia_semana BETWEEN 1 AND 7)',
+    'SELECT ''chk_horario_dia_semana ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-ALTER TABLE HorarioBase
-    ADD CONSTRAINT chk_horario_horas
-    CHECK (hora_inicio < hora_fin);
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE constraint_schema = DATABASE()
+      AND constraint_name = 'chk_horario_horas'
+      AND table_name = 'HorarioBase'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE HorarioBase ADD CONSTRAINT chk_horario_horas CHECK (hora_inicio < hora_fin)',
+    'SELECT ''chk_horario_horas ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-ALTER TABLE Slot
-    ADD CONSTRAINT chk_slot_horas
-    CHECK (hora_inicio < hora_fin);
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE constraint_schema = DATABASE()
+      AND constraint_name = 'chk_slot_horas'
+      AND table_name = 'Slot'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE Slot ADD CONSTRAINT chk_slot_horas CHECK (hora_inicio < hora_fin)',
+    'SELECT ''chk_slot_horas ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 -- 5) Índices recomendados para consultas comunes
-CREATE INDEX idx_usuario_email ON Usuario(email);
-CREATE INDEX idx_cita_usuario ON Cita(usuario_id);
-CREATE INDEX idx_cita_estado ON Cita(estado);
-CREATE INDEX idx_slot_estado_fecha ON Slot(estado, fecha);
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'Usuario'
+      AND index_name = 'idx_usuario_email'
+);
+SET @sql := IF(@exists = 0,
+    'CREATE INDEX idx_usuario_email ON Usuario(email)',
+    'SELECT ''idx_usuario_email ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'Cita'
+      AND index_name = 'idx_cita_usuario'
+);
+SET @sql := IF(@exists = 0,
+    'CREATE INDEX idx_cita_usuario ON Cita(usuario_id)',
+    'SELECT ''idx_cita_usuario ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'Cita'
+      AND index_name = 'idx_cita_estado'
+);
+SET @sql := IF(@exists = 0,
+    'CREATE INDEX idx_cita_estado ON Cita(estado)',
+    'SELECT ''idx_cita_estado ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'Slot'
+      AND index_name = 'idx_slot_estado_fecha'
+);
+SET @sql := IF(@exists = 0,
+    'CREATE INDEX idx_slot_estado_fecha ON Slot(estado, fecha)',
+    'SELECT ''idx_slot_estado_fecha ya existe''');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/backend/src/main/java/HerramientasDesarrollo/demo/DemoApplication.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/DemoApplication.java
@@ -4,6 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+/**
+ * Punto de arranque del backend SkipLine y raíz de escaneo de componentes Spring.
+ */
 public class DemoApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/HerramientasDesarrollo/demo/Security/CustomUserDetailsService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/Security/CustomUserDetailsService.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+/**
+ * Adaptador entre repositorio de usuarios y contrato UserDetailsService de Spring Security.
+ */
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UsuarioRepository usuarioRepository;

--- a/backend/src/main/java/HerramientasDesarrollo/demo/Security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/Security/JwtAuthenticationFilter.java
@@ -16,6 +16,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
+/**
+ * Filtro que extrae y valida JWT en cada request protegida para poblar el SecurityContext.
+ */
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
@@ -39,6 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             username = jwtService.extractUsername(jwt);
         } catch (Exception ex) {
+            // Si el token viene malformado o expirado, se deja continuar para que Security responda 401.
             filterChain.doFilter(request, response);
             return;
         }

--- a/backend/src/main/java/HerramientasDesarrollo/demo/Security/JwtService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/Security/JwtService.java
@@ -15,6 +15,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 @Service
+/**
+ * Encapsula creación y validación de JWT, incluyendo claims de negocio requeridos por la API.
+ */
 public class JwtService {
 
     @Value("${jwt.secret}")
@@ -30,6 +33,7 @@ public class JwtService {
     public String generateToken(UserDetails userDetails) {
         Map<String, Object> extraClaims = new HashMap<>();
         if (userDetails instanceof UserPrincipal userPrincipal) {
+            // Claims usados por clientes para personalizar experiencia sin llamadas extra.
             extraClaims.put("role", userPrincipal.getUsuario().getRol().name());
             extraClaims.put("nombre", userPrincipal.getUsuario().getNombre());
             extraClaims.put("userId", userPrincipal.getUsuario().getId());

--- a/backend/src/main/java/HerramientasDesarrollo/demo/Security/SecurityConfig.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/Security/SecurityConfig.java
@@ -20,6 +20,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableMethodSecurity
 @RequiredArgsConstructor
+/**
+ * Configuración central de seguridad: filtro JWT, sesión stateless y reglas de acceso por ruta.
+ */
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -28,6 +31,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                // API stateless: no se usa sesión de servidor ni formulario de login.
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
@@ -37,7 +41,13 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**"
                         ).permitAll()
-                        .requestMatchers("/api/users/**").authenticated()
+                        .requestMatchers(
+                            "/api/users/**",
+                            "/api/doctores/**",
+                            "/api/citas/**",
+                            "/api/horarios/**",
+                            "/api/slots/**"
+                        ).authenticated()
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/backend/src/main/java/HerramientasDesarrollo/demo/Security/UserPrincipal.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/Security/UserPrincipal.java
@@ -9,6 +9,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
+/**
+ * Proyección de Usuario al modelo de seguridad de Spring (credenciales y authorities).
+ */
 public class UserPrincipal implements UserDetails {
 
     private final Usuario usuario;

--- a/backend/src/main/java/HerramientasDesarrollo/demo/controller/AuthController.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/controller/AuthController.java
@@ -4,6 +4,10 @@ import HerramientasDesarrollo.demo.dto.auth.AuthResponse;
 import HerramientasDesarrollo.demo.dto.auth.LoginRequest;
 import HerramientasDesarrollo.demo.dto.auth.RegisterRequest;
 import HerramientasDesarrollo.demo.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,11 +21,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth", description = "Autenticación y registro de usuarios")
+/**
+ * Controlador responsable del ciclo de vida de autenticación (alta e inicio de sesión).
+ */
 public class AuthController {
 
     private final AuthService authService;
 
+    /**
+        * Registra usuarios nuevos. Si la solicitud intenta crear roles elevados,
+        * exige que quien invoca ya tenga privilegios de administrador.
+     */
     @PostMapping("/register")
+    @Operation(summary = "Registrar usuario", description = "Registra usuario; por defecto PACIENTE. ADMIN puede crear ADMIN/MEDICO")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Usuario registrado"),
+            @ApiResponse(responseCode = "400", description = "Datos invalidos"),
+            @ApiResponse(responseCode = "403", description = "No autorizado para asignar rol"),
+            @ApiResponse(responseCode = "409", description = "Email ya registrado")
+    })
     public ResponseEntity<AuthResponse> register(
             @Valid @RequestBody RegisterRequest request,
             Authentication authentication
@@ -29,7 +48,16 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(authService.register(request, authentication));
     }
 
+    /**
+        * Autentica credenciales y devuelve un JWT con claims de identidad y rol.
+     */
     @PostMapping("/login")
+    @Operation(summary = "Login", description = "Valida credenciales y retorna token JWT")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Login exitoso"),
+            @ApiResponse(responseCode = "400", description = "Datos invalidos"),
+            @ApiResponse(responseCode = "401", description = "Credenciales invalidas")
+    })
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
     }

--- a/backend/src/main/java/HerramientasDesarrollo/demo/controller/CitaController.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/controller/CitaController.java
@@ -1,0 +1,52 @@
+package HerramientasDesarrollo.demo.controller;
+
+import HerramientasDesarrollo.demo.dto.cita.CitaResponse;
+import HerramientasDesarrollo.demo.dto.cita.CreateCitaRequest;
+import HerramientasDesarrollo.demo.service.CitaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/citas")
+@RequiredArgsConstructor
+@Tag(name = "Citas", description = "Reserva de turnos para pacientes")
+/**
+ * Gestiona la confirmación de reservas desde la perspectiva del paciente.
+ */
+public class CitaController {
+
+    private final CitaService citaService;
+
+    /**
+        * Confirma una reserva sobre un slot concreto y delega en servicio la lógica anti doble reserva.
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('PACIENTE')")
+    @Operation(summary = "Crear cita", description = "Reserva un slot disponible para el paciente autenticado y lo marca como ocupado")
+        @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Cita creada"),
+            @ApiResponse(responseCode = "400", description = "Datos invalidos"),
+            @ApiResponse(responseCode = "401", description = "No autenticado"),
+            @ApiResponse(responseCode = "403", description = "Sin permisos"),
+            @ApiResponse(responseCode = "404", description = "Slot o usuario no encontrado"),
+            @ApiResponse(responseCode = "409", description = "Slot no disponible")
+        })
+    public ResponseEntity<CitaResponse> createCita(
+            @Valid @RequestBody CreateCitaRequest request,
+            Authentication authentication
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(citaService.createCita(request, authentication));
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/controller/DoctorController.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/controller/DoctorController.java
@@ -1,0 +1,66 @@
+package HerramientasDesarrollo.demo.controller;
+
+import HerramientasDesarrollo.demo.dto.doctor.DoctorListResponse;
+import HerramientasDesarrollo.demo.dto.slot.DoctorSlotResponse;
+import HerramientasDesarrollo.demo.service.DoctorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/doctores")
+@RequiredArgsConstructor
+@Tag(name = "Doctores", description = "Consultas de catálogo de médicos y disponibilidad")
+/**
+ * Endpoints de consulta para el catálogo médico visible en el flujo de agendamiento.
+ */
+public class DoctorController {
+
+    private final DoctorService doctorService;
+
+    /**
+     * Punto de entrada del buscador de doctores: aplica filtros opcionales y devuelve
+     * la información mínima para listar tarjetas en frontend.
+     */
+    @GetMapping
+    @Operation(summary = "Listar doctores", description = "Devuelve doctores con datos visibles en catálogo y próxima disponibilidad")
+        @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Listado obtenido"),
+            @ApiResponse(responseCode = "401", description = "No autenticado")
+        })
+    public ResponseEntity<List<DoctorListResponse>> listDoctors(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String especialidad
+    ) {
+        return ResponseEntity.ok(doctorService.listDoctors(search, especialidad));
+    }
+
+    /**
+     * Entrega la grilla diaria de disponibilidad de un médico, ordenada por hora,
+     * para que el cliente pueda habilitar selección de turno por franja.
+     */
+    @GetMapping("/{doctorId}/slots")
+    @Operation(summary = "Listar slots por doctor y fecha", description = "Retorna los turnos del día ordenados por hora")
+        @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Slots obtenidos"),
+            @ApiResponse(responseCode = "400", description = "Parametro de fecha invalido"),
+            @ApiResponse(responseCode = "401", description = "No autenticado")
+        })
+    public ResponseEntity<List<DoctorSlotResponse>> getDoctorSlotsByDate(
+            @PathVariable Long doctorId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return ResponseEntity.ok(doctorService.getDoctorSlotsByDate(doctorId, date));
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/controller/HorarioController.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/controller/HorarioController.java
@@ -1,0 +1,58 @@
+package HerramientasDesarrollo.demo.controller;
+
+import HerramientasDesarrollo.demo.dto.horario.CreateHorarioRequest;
+import HerramientasDesarrollo.demo.dto.horario.HorarioResponse;
+import HerramientasDesarrollo.demo.entity.HorarioBase;
+import HerramientasDesarrollo.demo.service.HorarioService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/horarios")
+@RequiredArgsConstructor
+@Tag(name = "Horarios", description = "Configuración de horarios base por doctor")
+/**
+ * Administración de disponibilidad estructural del médico (plantilla semanal).
+ */
+public class HorarioController {
+
+    private final HorarioService horarioService;
+
+    /**
+        * Registra un bloque base de atención y protege contra superposición horaria por doctor y día.
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Crear horario base", description = "Asigna horario base al doctor validando que no se superponga")
+        @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Horario creado"),
+            @ApiResponse(responseCode = "400", description = "Datos invalidos"),
+            @ApiResponse(responseCode = "401", description = "No autenticado"),
+            @ApiResponse(responseCode = "403", description = "Sin permisos"),
+            @ApiResponse(responseCode = "404", description = "Doctor no encontrado"),
+            @ApiResponse(responseCode = "409", description = "Horario superpuesto")
+        })
+    public ResponseEntity<HorarioResponse> createHorario(@Valid @RequestBody CreateHorarioRequest request) {
+        HorarioBase saved = horarioService.createHorario(request);
+        HorarioResponse response = HorarioResponse.builder()
+                .id(saved.getId())
+                .doctorId(saved.getDoctor().getId())
+                .diaSemana(saved.getDiaSemana())
+                .horaInicio(saved.getHoraInicio())
+                .horaFin(saved.getHoraFin())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/controller/SlotController.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/controller/SlotController.java
@@ -1,0 +1,48 @@
+package HerramientasDesarrollo.demo.controller;
+
+import HerramientasDesarrollo.demo.dto.slot.GenerateSlotsRequest;
+import HerramientasDesarrollo.demo.dto.slot.GenerateSlotsResponse;
+import HerramientasDesarrollo.demo.service.SlotService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/slots")
+@RequiredArgsConstructor
+@Tag(name = "Slots", description = "Generación y administración de slots")
+/**
+ * Expone operaciones batch sobre slots derivados de horarios base.
+ */
+public class SlotController {
+
+    private final SlotService slotService;
+
+    /**
+        * Materializa agenda en bloques de 30 minutos dentro de un rango de fechas,
+        * evitando duplicar franjas ya existentes.
+     */
+    @PostMapping("/generar")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Generar slots", description = "Genera slots de 30 minutos en un rango de fechas evitando duplicados")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Slots generados"),
+            @ApiResponse(responseCode = "400", description = "Datos invalidos"),
+            @ApiResponse(responseCode = "401", description = "No autenticado"),
+            @ApiResponse(responseCode = "403", description = "Sin permisos"),
+            @ApiResponse(responseCode = "404", description = "Doctor no encontrado"),
+            @ApiResponse(responseCode = "409", description = "Conflicto de negocio")
+    })
+    public ResponseEntity<GenerateSlotsResponse> generarSlots(@Valid @RequestBody GenerateSlotsRequest request) {
+        return ResponseEntity.ok(slotService.generarSlots(request));
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/controller/UserController.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/controller/UserController.java
@@ -3,6 +3,10 @@ package HerramientasDesarrollo.demo.controller;
 import HerramientasDesarrollo.demo.dto.user.CreateUserRequest;
 import HerramientasDesarrollo.demo.dto.user.UserResponse;
 import HerramientasDesarrollo.demo.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,23 +23,55 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Tag(name = "Usuarios", description = "Gestion de usuarios y perfil del autenticado")
+/**
+ * Endpoints de administración de cuentas y auto-consulta de perfil.
+ */
 public class UserController {
 
     private final UserService userService;
 
+    /**
+        * Devuelve el padrón completo de usuarios para pantallas administrativas.
+     */
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Listar usuarios", description = "Retorna todos los usuarios (solo ADMIN)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Listado obtenido"),
+            @ApiResponse(responseCode = "401", description = "No autenticado"),
+            @ApiResponse(responseCode = "403", description = "Sin permisos")
+    })
     public ResponseEntity<List<UserResponse>> getAllUsers() {
         return ResponseEntity.ok(userService.findAll());
     }
 
+    /**
+        * Permite alta asistida de usuarios desde backoffice, incluyendo personal médico y administradores.
+     */
     @PostMapping("/create")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Crear usuario", description = "Crea un usuario con rol ADMIN/MEDICO/PACIENTE (solo ADMIN)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Usuario creado"),
+            @ApiResponse(responseCode = "400", description = "Datos invalidos"),
+            @ApiResponse(responseCode = "401", description = "No autenticado"),
+            @ApiResponse(responseCode = "403", description = "Sin permisos"),
+            @ApiResponse(responseCode = "409", description = "Email ya registrado")
+    })
     public ResponseEntity<UserResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.createByAdmin(request));
     }
 
+    /**
+        * Endpoint de auto-perfil para mostrar datos de sesión y personalizar la interfaz.
+     */
     @GetMapping("/me")
+    @Operation(summary = "Perfil propio", description = "Retorna los datos del usuario autenticado")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Perfil obtenido"),
+            @ApiResponse(responseCode = "401", description = "No autenticado")
+    })
     public ResponseEntity<UserResponse> me(Authentication authentication) {
         return ResponseEntity.ok(userService.getCurrentUser(authentication));
     }

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/auth/AuthResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/auth/AuthResponse.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 
 @Getter
 @Builder
+/**
+ * Respuesta estandar de autenticación con token y datos básicos del usuario.
+ */
 public class AuthResponse {
     private String token;
     private String tokenType;

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/auth/LoginRequest.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/auth/LoginRequest.java
@@ -7,6 +7,9 @@ import lombok.Setter;
 
 @Getter
 @Setter
+/**
+ * Payload de autenticación por credenciales (email + password).
+ */
 public class LoginRequest {
 
     @NotBlank(message = "El email es obligatorio")

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/auth/RegisterRequest.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 
 @Getter
 @Setter
+/**
+ * Datos de alta de usuario; el rol se valida por política de seguridad en servicio.
+ */
 public class RegisterRequest {
 
     @NotBlank(message = "El nombre es obligatorio")

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/cita/CitaResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/cita/CitaResponse.java
@@ -1,0 +1,23 @@
+package HerramientasDesarrollo.demo.dto.cita;
+
+import HerramientasDesarrollo.demo.entity.CitaEstado;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+/**
+ * Resumen de la cita creada con datos de agenda necesarios para confirmación visual.
+ */
+public class CitaResponse {
+    private Long id;
+    private Long slotId;
+    private Long doctorId;
+    private LocalDate fecha;
+    private LocalTime horaInicio;
+    private LocalTime horaFin;
+    private CitaEstado estado;
+    private String motivo;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/cita/CreateCitaRequest.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/cita/CreateCitaRequest.java
@@ -1,0 +1,22 @@
+package HerramientasDesarrollo.demo.dto.cita;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+/**
+ * Entrada para reservar una cita sobre un slot puntual.
+ */
+public class CreateCitaRequest {
+
+    @NotNull(message = "slotId es obligatorio")
+    private Long slotId;
+
+    @NotBlank(message = "El motivo es obligatorio")
+    @Size(max = 255, message = "El motivo no puede superar 255 caracteres")
+    private String motivo;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/common/ErrorResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/common/ErrorResponse.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 
 @Getter
 @Builder
+/**
+ * Estructura uniforme de errores devueltos por la API.
+ */
 public class ErrorResponse {
     private LocalDateTime timestamp;
     private int status;

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/doctor/DoctorListResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/doctor/DoctorListResponse.java
@@ -1,0 +1,23 @@
+package HerramientasDesarrollo.demo.dto.doctor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+/**
+ * Proyección ligera para listado de doctores con próxima disponibilidad.
+ */
+public class DoctorListResponse {
+    private Long id;
+    private String nombre;
+    private String especialidad;
+    private Integer experiencia;
+    private String consultorio;
+    private String foto;
+    private LocalDate proximaFechaDisponible;
+    private LocalTime proximaHoraDisponible;
+    private String estado;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/horario/CreateHorarioRequest.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/horario/CreateHorarioRequest.java
@@ -1,0 +1,31 @@
+package HerramientasDesarrollo.demo.dto.horario;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+/**
+ * Entrada para definir disponibilidad semanal de un médico.
+ */
+public class CreateHorarioRequest {
+
+    @NotNull(message = "doctorId es obligatorio")
+    private Long doctorId;
+
+    @NotNull(message = "diaSemana es obligatorio")
+    @Min(value = 1, message = "diaSemana debe estar entre 1 y 7")
+    @Max(value = 7, message = "diaSemana debe estar entre 1 y 7")
+    private Integer diaSemana;
+
+    @NotNull(message = "horaInicio es obligatoria")
+    private LocalTime horaInicio;
+
+    @NotNull(message = "horaFin es obligatoria")
+    private LocalTime horaFin;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/horario/HorarioResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/horario/HorarioResponse.java
@@ -1,0 +1,18 @@
+package HerramientasDesarrollo.demo.dto.horario;
+
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+/**
+ * Resultado de creación de horario base.
+ */
+public class HorarioResponse {
+    private Long id;
+    private Long doctorId;
+    private Integer diaSemana;
+    private LocalTime horaInicio;
+    private LocalTime horaFin;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/slot/DoctorSlotResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/slot/DoctorSlotResponse.java
@@ -1,0 +1,18 @@
+package HerramientasDesarrollo.demo.dto.slot;
+
+import HerramientasDesarrollo.demo.entity.SlotEstado;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+/**
+ * Proyección de un slot para visualización diaria de agenda.
+ */
+public class DoctorSlotResponse {
+    private Long id;
+    private LocalTime horaInicio;
+    private LocalTime horaFin;
+    private SlotEstado estado;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/slot/GenerateSlotsRequest.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/slot/GenerateSlotsRequest.java
@@ -1,0 +1,23 @@
+package HerramientasDesarrollo.demo.dto.slot;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+/**
+ * Parámetros de generación masiva de slots para un médico en un intervalo de fechas.
+ */
+public class GenerateSlotsRequest {
+
+    @NotNull(message = "doctorId es obligatorio")
+    private Long doctorId;
+
+    @NotNull(message = "fechaInicio es obligatoria")
+    private LocalDate fechaInicio;
+
+    @NotNull(message = "fechaFin es obligatoria")
+    private LocalDate fechaFin;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/slot/GenerateSlotsResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/slot/GenerateSlotsResponse.java
@@ -1,0 +1,14 @@
+package HerramientasDesarrollo.demo.dto.slot;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+/**
+ * Resultado agregado de la operación batch de generación de slots.
+ */
+public class GenerateSlotsResponse {
+    private Long doctorId;
+    private int slotsGenerados;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/user/CreateUserRequest.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/user/CreateUserRequest.java
@@ -10,6 +10,9 @@ import lombok.Setter;
 
 @Getter
 @Setter
+/**
+ * Datos para alta administrativa de usuarios con rol explícito.
+ */
 public class CreateUserRequest {
 
     @NotBlank(message = "El nombre es obligatorio")

--- a/backend/src/main/java/HerramientasDesarrollo/demo/dto/user/UserResponse.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/dto/user/UserResponse.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 
 @Getter
 @Builder
+/**
+ * Vista pública de usuario sin exponer credenciales.
+ */
 public class UserResponse {
     private Long id;
     private String nombre;

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/Cita.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/Cita.java
@@ -4,46 +4,45 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "Usuario")
+@Table(name = "Cita")
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 /**
- * Entidad de identidad del sistema. Modela credenciales, rol y metadatos de alta.
+ * Reserva confirmada de un paciente sobre un slot específico.
  */
-public class Usuario {
+public class Cita {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 120)
-    private String nombre;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
 
-    @Column(nullable = false, unique = true, length = 150)
-    private String email;
-
-    @Column(nullable = false)
-    private String password;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "slot_id", nullable = false, unique = true)
+    private Slot slot;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private Role rol;
+    private CitaEstado estado;
+
+    @Column(length = 255)
+    private String motivo;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/CitaEstado.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/CitaEstado.java
@@ -1,0 +1,11 @@
+package HerramientasDesarrollo.demo.entity;
+
+/**
+ * Ciclo de vida de una cita desde su creación hasta cierre o cancelación.
+ */
+public enum CitaEstado {
+    RESERVADA,
+    CONFIRMADA,
+    ATENDIDA,
+    CANCELADA
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/Doctor.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/Doctor.java
@@ -1,0 +1,56 @@
+package HerramientasDesarrollo.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "Doctor")
+@Getter
+@Setter
+/**
+ * Representa un profesional de salud disponible para agendamiento.
+ */
+public class Doctor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String nombre;
+
+    @Column(nullable = false, length = 100)
+    private String apellido;
+
+    @Column(name = "experiencia_anios")
+    private Integer experienciaAnios;
+
+    @Column(length = 50)
+    private String consultorio;
+
+    @Column(name = "foto_url", length = 255)
+    private String fotoUrl;
+
+    @Column(name = "clinica_id", nullable = false)
+    private Long clinicaId;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "DoctorEspecialidad",
+            joinColumns = @JoinColumn(name = "doctor_id"),
+            inverseJoinColumns = @JoinColumn(name = "especialidad_id")
+    )
+    private Set<Especialidad> especialidades = new HashSet<>();
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/Especialidad.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/Especialidad.java
@@ -1,0 +1,30 @@
+package HerramientasDesarrollo.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "Especialidad")
+@Getter
+@Setter
+/**
+ * Catálogo de especialidades médicas que se vinculan a doctores.
+ */
+public class Especialidad {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String nombre;
+
+    @Column(length = 255)
+    private String descripcion;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/HorarioBase.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/HorarioBase.java
@@ -1,0 +1,41 @@
+package HerramientasDesarrollo.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "HorarioBase")
+@Getter
+@Setter
+/**
+ * Plantilla semanal de atención de un doctor; base para generación automática de slots.
+ */
+public class HorarioBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "doctor_id", nullable = false)
+    private Doctor doctor;
+
+    @Column(name = "dia_semana", nullable = false)
+    private Integer diaSemana;
+
+    @Column(name = "hora_inicio", nullable = false)
+    private LocalTime horaInicio;
+
+    @Column(name = "hora_fin", nullable = false)
+    private LocalTime horaFin;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/Role.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/Role.java
@@ -1,5 +1,8 @@
 package HerramientasDesarrollo.demo.entity;
 
+/**
+ * Roles de autorización usados por Spring Security para control de acceso.
+ */
 public enum Role {
     ADMIN,
     MEDICO,

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/Slot.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/Slot.java
@@ -1,0 +1,48 @@
+package HerramientasDesarrollo.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "Slot")
+@Getter
+@Setter
+/**
+ * Unidad mínima de disponibilidad en agenda, con fecha/hora y estado operacional.
+ */
+public class Slot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "doctor_id", nullable = false)
+    private Doctor doctor;
+
+    @Column(nullable = false)
+    private LocalDate fecha;
+
+    @Column(name = "hora_inicio", nullable = false)
+    private LocalTime horaInicio;
+
+    @Column(name = "hora_fin", nullable = false)
+    private LocalTime horaFin;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SlotEstado estado;
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/entity/SlotEstado.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/entity/SlotEstado.java
@@ -1,0 +1,11 @@
+package HerramientasDesarrollo.demo.entity;
+
+/**
+ * Estado operativo de una franja horaria en agenda.
+ */
+public enum SlotEstado {
+    DISPONIBLE,
+    OCUPADO,
+    RESERVADO,
+    CANCELADO
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/exception/EmailAlreadyExistsException.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/exception/EmailAlreadyExistsException.java
@@ -1,5 +1,8 @@
 package HerramientasDesarrollo.demo.exception;
 
+/**
+ * Se lanza cuando una operación de alta intenta reutilizar un email existente.
+ */
 public class EmailAlreadyExistsException extends RuntimeException {
     public EmailAlreadyExistsException(String message) {
         super(message);

--- a/backend/src/main/java/HerramientasDesarrollo/demo/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/exception/GlobalExceptionHandler.java
@@ -14,6 +14,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+/**
+ * Traduce excepciones técnicas y de negocio a respuestas HTTP consistentes para clientes.
+ */
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(EmailAlreadyExistsException.class)
@@ -46,6 +49,30 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         return buildError(HttpStatus.FORBIDDEN, "No tienes permisos para acceder a este recurso", request.getRequestURI());
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFound(
+            ResourceNotFoundException ex,
+            HttpServletRequest request
+    ) {
+        return buildError(HttpStatus.NOT_FOUND, ex.getMessage(), request.getRequestURI());
+    }
+
+    @ExceptionHandler({SlotNotAvailableException.class, ScheduleOverlapException.class})
+    public ResponseEntity<ErrorResponse> handleBusinessConflict(
+            RuntimeException ex,
+            HttpServletRequest request
+    ) {
+        return buildError(HttpStatus.CONFLICT, ex.getMessage(), request.getRequestURI());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(
+            IllegalArgumentException ex,
+            HttpServletRequest request
+    ) {
+        return buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/HerramientasDesarrollo/demo/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/exception/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package HerramientasDesarrollo.demo.exception;
+
+/**
+ * Señala que una entidad requerida para la operación no existe.
+ */
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/exception/ScheduleOverlapException.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/exception/ScheduleOverlapException.java
@@ -1,0 +1,10 @@
+package HerramientasDesarrollo.demo.exception;
+
+/**
+ * Error de negocio para bloques horarios que se superponen en un mismo doctor/día.
+ */
+public class ScheduleOverlapException extends RuntimeException {
+    public ScheduleOverlapException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/exception/SlotNotAvailableException.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/exception/SlotNotAvailableException.java
@@ -1,0 +1,10 @@
+package HerramientasDesarrollo.demo.exception;
+
+/**
+ * Error de conflicto cuando se intenta reservar un slot no disponible.
+ */
+public class SlotNotAvailableException extends RuntimeException {
+    public SlotNotAvailableException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/exception/UnauthorizedRoleAssignmentException.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/exception/UnauthorizedRoleAssignmentException.java
@@ -1,5 +1,8 @@
 package HerramientasDesarrollo.demo.exception;
 
+/**
+ * Indica intento de asignar roles privilegiados sin permisos administrativos.
+ */
 public class UnauthorizedRoleAssignmentException extends RuntimeException {
     public UnauthorizedRoleAssignmentException(String message) {
         super(message);

--- a/backend/src/main/java/HerramientasDesarrollo/demo/repository/CitaRepository.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/repository/CitaRepository.java
@@ -1,0 +1,11 @@
+package HerramientasDesarrollo.demo.repository;
+
+import HerramientasDesarrollo.demo.entity.Cita;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Persistencia de reservas y validación de unicidad por slot.
+ */
+public interface CitaRepository extends JpaRepository<Cita, Long> {
+    boolean existsBySlotId(Long slotId);
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/repository/DoctorRepository.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/repository/DoctorRepository.java
@@ -1,0 +1,24 @@
+package HerramientasDesarrollo.demo.repository;
+
+import HerramientasDesarrollo.demo.entity.Doctor;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Provee consultas optimizadas para listado de doctores con filtros de catálogo.
+ */
+public interface DoctorRepository extends JpaRepository<Doctor, Long> {
+
+    @Query("""
+            select distinct d from Doctor d
+            left join fetch d.especialidades e
+            where (:search is null or :search = '' or lower(concat(coalesce(d.nombre,''), ' ', coalesce(d.apellido,''), ' ', coalesce(d.consultorio,''))) like lower(concat('%', :search, '%')))
+              and (:especialidad is null or :especialidad = '' or lower(e.nombre) = lower(:especialidad))
+            """)
+    List<Doctor> findForListing(
+            @Param("search") String search,
+            @Param("especialidad") String especialidad
+    );
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/repository/HorarioBaseRepository.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/repository/HorarioBaseRepository.java
@@ -1,0 +1,21 @@
+package HerramientasDesarrollo.demo.repository;
+
+import HerramientasDesarrollo.demo.entity.HorarioBase;
+import java.time.LocalTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Persistencia de plantillas semanales y validaciones de superposición horaria.
+ */
+public interface HorarioBaseRepository extends JpaRepository<HorarioBase, Long> {
+
+    List<HorarioBase> findByDoctorId(Long doctorId);
+
+    boolean existsByDoctorIdAndDiaSemanaAndHoraInicioLessThanAndHoraFinGreaterThan(
+            Long doctorId,
+            Integer diaSemana,
+            LocalTime horaFin,
+            LocalTime horaInicio
+    );
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/repository/SlotRepository.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/repository/SlotRepository.java
@@ -1,0 +1,30 @@
+package HerramientasDesarrollo.demo.repository;
+
+import HerramientasDesarrollo.demo.entity.Slot;
+import HerramientasDesarrollo.demo.entity.SlotEstado;
+import jakarta.persistence.LockModeType;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+/**
+ * Consultas de agenda por doctor/fecha y lectura con lock para reservas seguras.
+ */
+public interface SlotRepository extends JpaRepository<Slot, Long> {
+
+    List<Slot> findByDoctorIdAndFechaOrderByHoraInicioAsc(Long doctorId, LocalDate fecha);
+
+    List<Slot> findByDoctorIdAndEstadoAndFechaGreaterThanEqualOrderByFechaAscHoraInicioAsc(
+            Long doctorId,
+            SlotEstado estado,
+            LocalDate fecha
+    );
+
+    boolean existsByDoctorIdAndFechaAndHoraInicio(Long doctorId, LocalDate fecha, LocalTime horaInicio);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Slot> findWithLockingById(Long id);
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/repository/UsuarioRepository.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/repository/UsuarioRepository.java
@@ -4,6 +4,9 @@ import HerramientasDesarrollo.demo.entity.Usuario;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * Acceso a datos de usuarios con consultas orientadas a autenticación.
+ */
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
     Optional<Usuario> findByEmail(String email);
 

--- a/backend/src/main/java/HerramientasDesarrollo/demo/service/AuthService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/service/AuthService.java
@@ -21,6 +21,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+/**
+ * Orquesta registro e inicio de sesión, incluyendo reglas de negocio de roles.
+ */
 public class AuthService {
 
     private final UsuarioRepository usuarioRepository;
@@ -30,6 +33,7 @@ public class AuthService {
     private final UserService userService;
 
     public AuthResponse register(RegisterRequest request, Authentication authentication) {
+        // Primera barrera de integridad para evitar colisión de credenciales.
         if (usuarioRepository.existsByEmail(request.getEmail())) {
             throw new EmailAlreadyExistsException("El email ya está registrado");
         }
@@ -37,6 +41,7 @@ public class AuthService {
         Role requestedRole = request.getRol() != null ? request.getRol() : Role.PACIENTE;
         boolean adminCreatingPrivilegedUser = requestedRole == Role.ADMIN || requestedRole == Role.MEDICO;
 
+        // Solo un ADMIN autenticado puede provisionar cuentas de administración o médicas.
         if (adminCreatingPrivilegedUser && !isAuthenticatedAdmin(authentication)) {
             throw new UnauthorizedRoleAssignmentException(
                     "Solo ADMIN puede registrar usuarios con rol ADMIN o MEDICO"
@@ -65,6 +70,7 @@ public class AuthService {
     public AuthResponse login(LoginRequest request) {
         Authentication authentication;
         try {
+            // Delega validación de credenciales al AuthenticationManager configurado en Security.
             authentication = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
             );

--- a/backend/src/main/java/HerramientasDesarrollo/demo/service/CitaService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/service/CitaService.java
@@ -1,0 +1,77 @@
+package HerramientasDesarrollo.demo.service;
+
+import HerramientasDesarrollo.demo.dto.cita.CitaResponse;
+import HerramientasDesarrollo.demo.dto.cita.CreateCitaRequest;
+import HerramientasDesarrollo.demo.entity.Cita;
+import HerramientasDesarrollo.demo.entity.CitaEstado;
+import HerramientasDesarrollo.demo.entity.Slot;
+import HerramientasDesarrollo.demo.entity.SlotEstado;
+import HerramientasDesarrollo.demo.entity.Usuario;
+import HerramientasDesarrollo.demo.exception.ResourceNotFoundException;
+import HerramientasDesarrollo.demo.exception.SlotNotAvailableException;
+import HerramientasDesarrollo.demo.repository.CitaRepository;
+import HerramientasDesarrollo.demo.repository.SlotRepository;
+import HerramientasDesarrollo.demo.repository.UsuarioRepository;
+import HerramientasDesarrollo.demo.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+/**
+ * Maneja la reserva transaccional de citas, garantizando consistencia entre Cita y Slot.
+ */
+public class CitaService {
+
+    private final CitaRepository citaRepository;
+    private final SlotRepository slotRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    @Transactional
+    public CitaResponse createCita(CreateCitaRequest request, Authentication authentication) {
+        Long usuarioId = getAuthenticatedUserId(authentication);
+
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuario no encontrado"));
+
+        // Bloqueo pesimista para evitar doble reserva cuando hay concurrencia alta.
+        Slot slot = slotRepository.findWithLockingById(request.getSlotId())
+                .orElseThrow(() -> new ResourceNotFoundException("Slot no encontrado"));
+
+        // Doble validación por estado + existencia de cita vinculada al slot.
+        if (slot.getEstado() != SlotEstado.DISPONIBLE || citaRepository.existsBySlotId(slot.getId())) {
+            throw new SlotNotAvailableException("El slot ya no está disponible");
+        }
+
+        Cita cita = new Cita();
+        cita.setUsuario(usuario);
+        cita.setSlot(slot);
+        cita.setEstado(CitaEstado.RESERVADA);
+        cita.setMotivo(request.getMotivo());
+
+        slot.setEstado(SlotEstado.OCUPADO);
+        slotRepository.save(slot);
+
+        Cita saved = citaRepository.save(cita);
+
+        return CitaResponse.builder()
+                .id(saved.getId())
+                .slotId(saved.getSlot().getId())
+                .doctorId(saved.getSlot().getDoctor().getId())
+                .fecha(saved.getSlot().getFecha())
+                .horaInicio(saved.getSlot().getHoraInicio())
+                .horaFin(saved.getSlot().getHoraFin())
+                .estado(saved.getEstado())
+                .motivo(saved.getMotivo())
+                .build();
+    }
+
+    private Long getAuthenticatedUserId(Authentication authentication) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof UserPrincipal principal)) {
+            throw new IllegalStateException("Usuario no autenticado");
+        }
+        return principal.getUsuario().getId();
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/service/DoctorService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/service/DoctorService.java
@@ -1,0 +1,88 @@
+package HerramientasDesarrollo.demo.service;
+
+import HerramientasDesarrollo.demo.dto.doctor.DoctorListResponse;
+import HerramientasDesarrollo.demo.dto.slot.DoctorSlotResponse;
+import HerramientasDesarrollo.demo.entity.Doctor;
+import HerramientasDesarrollo.demo.entity.Especialidad;
+import HerramientasDesarrollo.demo.entity.Slot;
+import HerramientasDesarrollo.demo.entity.SlotEstado;
+import HerramientasDesarrollo.demo.repository.DoctorRepository;
+import HerramientasDesarrollo.demo.repository.SlotRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+/**
+ * Expone proyecciones de doctores orientadas a consulta pública y agenda diaria.
+ */
+public class DoctorService {
+
+    private final DoctorRepository doctorRepository;
+    private final SlotRepository slotRepository;
+
+    @Transactional(readOnly = true)
+    public List<DoctorListResponse> listDoctors(String search, String especialidad) {
+        List<Doctor> doctors = doctorRepository.findForListing(search, especialidad);
+
+        return doctors.stream()
+                .map(this::toDoctorListResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<DoctorSlotResponse> getDoctorSlotsByDate(Long doctorId, LocalDate date) {
+        List<Slot> slots = slotRepository.findByDoctorIdAndFechaOrderByHoraInicioAsc(doctorId, date);
+        return slots.stream()
+                .map(slot -> DoctorSlotResponse.builder()
+                        .id(slot.getId())
+                        .horaInicio(slot.getHoraInicio())
+                        .horaFin(slot.getHoraFin())
+                        .estado(slot.getEstado())
+                        .build())
+                .toList();
+    }
+
+    private DoctorListResponse toDoctorListResponse(Doctor doctor) {
+        Slot nextSlot = findNextAvailableSlot(doctor.getId());
+                // Se concatena en una cadena única para simplificar renderizado en tarjetas de listado.
+        String especialidadTexto = doctor.getEspecialidades().stream()
+                .map(Especialidad::getNombre)
+                .sorted()
+                .collect(Collectors.joining(", "));
+
+        return DoctorListResponse.builder()
+                .id(doctor.getId())
+                .nombre(doctor.getNombre() + " " + doctor.getApellido())
+                .especialidad(especialidadTexto)
+                .experiencia(doctor.getExperienciaAnios())
+                .consultorio(doctor.getConsultorio())
+                .foto(doctor.getFotoUrl())
+                .proximaFechaDisponible(nextSlot != null ? nextSlot.getFecha() : null)
+                .proximaHoraDisponible(nextSlot != null ? nextSlot.getHoraInicio() : null)
+                .estado(nextSlot != null ? "DISPONIBLE" : "SIN_DISPONIBILIDAD")
+                .build();
+    }
+
+    private Slot findNextAvailableSlot(Long doctorId) {
+        List<Slot> available = slotRepository.findByDoctorIdAndEstadoAndFechaGreaterThanEqualOrderByFechaAscHoraInicioAsc(
+                doctorId,
+                SlotEstado.DISPONIBLE,
+                LocalDate.now()
+        );
+
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        // Si no hay slots futuros estrictos, se devuelve el primero disponible como fallback funcional.
+        return available.stream()
+                .filter(s -> s.getFecha().isAfter(today) || !s.getHoraInicio().isBefore(now))
+                .findFirst()
+                .orElse(available.isEmpty() ? null : available.getFirst());
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/service/HorarioService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/service/HorarioService.java
@@ -1,0 +1,53 @@
+package HerramientasDesarrollo.demo.service;
+
+import HerramientasDesarrollo.demo.dto.horario.CreateHorarioRequest;
+import HerramientasDesarrollo.demo.entity.Doctor;
+import HerramientasDesarrollo.demo.entity.HorarioBase;
+import HerramientasDesarrollo.demo.exception.ResourceNotFoundException;
+import HerramientasDesarrollo.demo.exception.ScheduleOverlapException;
+import HerramientasDesarrollo.demo.repository.DoctorRepository;
+import HerramientasDesarrollo.demo.repository.HorarioBaseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+/**
+ * Administra la plantilla semanal de atención de cada médico.
+ */
+public class HorarioService {
+
+    private final HorarioBaseRepository horarioBaseRepository;
+    private final DoctorRepository doctorRepository;
+
+    @Transactional
+    public HorarioBase createHorario(CreateHorarioRequest request) {
+        if (!request.getHoraInicio().isBefore(request.getHoraFin())) {
+            throw new IllegalArgumentException("horaInicio debe ser menor que horaFin");
+        }
+
+        Doctor doctor = doctorRepository.findById(request.getDoctorId())
+                .orElseThrow(() -> new ResourceNotFoundException("Doctor no encontrado"));
+
+        boolean overlap = horarioBaseRepository.existsByDoctorIdAndDiaSemanaAndHoraInicioLessThanAndHoraFinGreaterThan(
+                request.getDoctorId(),
+                request.getDiaSemana(),
+                request.getHoraFin(),
+                request.getHoraInicio()
+        );
+
+        // Regla de negocio clave: un médico no puede tener dos bloques que se crucen.
+        if (overlap) {
+            throw new ScheduleOverlapException("El horario se superpone con otro horario base del doctor");
+        }
+
+        HorarioBase horarioBase = new HorarioBase();
+        horarioBase.setDoctor(doctor);
+        horarioBase.setDiaSemana(request.getDiaSemana());
+        horarioBase.setHoraInicio(request.getHoraInicio());
+        horarioBase.setHoraFin(request.getHoraFin());
+
+        return horarioBaseRepository.save(horarioBase);
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/service/SlotService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/service/SlotService.java
@@ -1,0 +1,90 @@
+package HerramientasDesarrollo.demo.service;
+
+import HerramientasDesarrollo.demo.dto.slot.GenerateSlotsRequest;
+import HerramientasDesarrollo.demo.dto.slot.GenerateSlotsResponse;
+import HerramientasDesarrollo.demo.entity.Doctor;
+import HerramientasDesarrollo.demo.entity.HorarioBase;
+import HerramientasDesarrollo.demo.entity.Slot;
+import HerramientasDesarrollo.demo.entity.SlotEstado;
+import HerramientasDesarrollo.demo.exception.ResourceNotFoundException;
+import HerramientasDesarrollo.demo.repository.DoctorRepository;
+import HerramientasDesarrollo.demo.repository.HorarioBaseRepository;
+import HerramientasDesarrollo.demo.repository.SlotRepository;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+/**
+ * Genera disponibilidad operativa (slots) a partir de la configuración base de horarios.
+ */
+public class SlotService {
+
+    private static final int SLOT_MINUTES = 30;
+
+    private final DoctorRepository doctorRepository;
+    private final HorarioBaseRepository horarioBaseRepository;
+    private final SlotRepository slotRepository;
+
+    @Transactional
+    public GenerateSlotsResponse generarSlots(GenerateSlotsRequest request) {
+        if (request.getFechaInicio().isAfter(request.getFechaFin())) {
+            throw new IllegalArgumentException("fechaInicio no puede ser mayor que fechaFin");
+        }
+
+        Doctor doctor = doctorRepository.findById(request.getDoctorId())
+                .orElseThrow(() -> new ResourceNotFoundException("Doctor no encontrado"));
+
+        List<HorarioBase> horarios = horarioBaseRepository.findByDoctorId(request.getDoctorId());
+        if (horarios.isEmpty()) {
+            throw new IllegalStateException("El doctor no tiene horarios base configurados");
+        }
+
+        List<Slot> toSave = new ArrayList<>();
+
+        for (LocalDate date = request.getFechaInicio(); !date.isAfter(request.getFechaFin()); date = date.plusDays(1)) {
+            int diaSemana = mapToApiDay(date.getDayOfWeek());
+            for (HorarioBase horario : horarios) {
+                if (!horario.getDiaSemana().equals(diaSemana)) {
+                    continue;
+                }
+                // Fragmenta cada bloque horario en segmentos atómicos de 30 minutos.
+                buildSlotsForDate(doctor, date, horario.getHoraInicio(), horario.getHoraFin(), toSave);
+            }
+        }
+
+        slotRepository.saveAll(toSave);
+
+        return GenerateSlotsResponse.builder()
+                .doctorId(doctor.getId())
+                .slotsGenerados(toSave.size())
+                .build();
+    }
+
+    private void buildSlotsForDate(Doctor doctor, LocalDate date, LocalTime start, LocalTime end, List<Slot> toSave) {
+        LocalTime current = start;
+        while (!current.plusMinutes(SLOT_MINUTES).isAfter(end)) {
+            // Evita duplicados si la generación se ejecuta más de una vez sobre el mismo rango.
+            if (!slotRepository.existsByDoctorIdAndFechaAndHoraInicio(doctor.getId(), date, current)) {
+                Slot slot = new Slot();
+                slot.setDoctor(doctor);
+                slot.setFecha(date);
+                slot.setHoraInicio(current);
+                slot.setHoraFin(current.plusMinutes(SLOT_MINUTES));
+                slot.setEstado(SlotEstado.DISPONIBLE);
+                toSave.add(slot);
+            }
+            current = current.plusMinutes(SLOT_MINUTES);
+        }
+    }
+
+    private int mapToApiDay(DayOfWeek dayOfWeek) {
+        return dayOfWeek.getValue();
+    }
+}

--- a/backend/src/main/java/HerramientasDesarrollo/demo/service/UserService.java
+++ b/backend/src/main/java/HerramientasDesarrollo/demo/service/UserService.java
@@ -14,6 +14,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+/**
+ * Capa de aplicación para administración de usuarios y proyección de perfil.
+ */
 public class UserService {
 
     private final UsuarioRepository usuarioRepository;
@@ -26,6 +29,7 @@ public class UserService {
     }
 
     public UserResponse createByAdmin(CreateUserRequest request) {
+        // El alta administrativa valida unicidad antes de persistir para devolver error de negocio claro.
         if (usuarioRepository.existsByEmail(request.getEmail())) {
             throw new EmailAlreadyExistsException("El email ya está registrado");
         }


### PR DESCRIPTION
Agregar listado de doctores con filtros y consulta de slots por fecha; implementar reserva de citas con protección contra doble reserva; agregar asignación de horario base y generación automática de slots de 30 minutos; extender seguridad por rutas y manejo de excepciones de negocio; actualizar script SQL para creación idempotente de constraints e índices; mejorar mantenibilidad con documentación técnica y guía de onboarding del backend.